### PR TITLE
fix: bring non-changing direction back

### DIFF
--- a/src/main/java/com/camerapoints/CameraPointsPlugin.java
+++ b/src/main/java/com/camerapoints/CameraPointsPlugin.java
@@ -128,8 +128,11 @@ public class CameraPointsPlugin extends Plugin
 	public void setCamera(CameraPoint cameraPoint)
 	{
 		clientThread.invoke(() -> {
-			CameraPoint.Direction direction = cameraPoint.getDirection() == null ? CameraPoint.Direction.NORTH : cameraPoint.getDirection();
-			client.runScript(SCRIPTID_COMPASS_ANGLE, direction.getScriptValue());
+			var direction = cameraPoint.getDirection() == null ? CameraPoint.Direction.NONE : cameraPoint.getDirection();
+			if (direction != CameraPoint.Direction.NONE)
+			{
+				client.runScript(SCRIPTID_COMPASS_ANGLE, direction.getScriptValue());
+			}
 			if (cameraPoint.isApplyZoom())
 			{
 				client.runScript(ScriptID.CAMERA_DO_ZOOM, cameraPoint.getZoom(), cameraPoint.getZoom());

--- a/src/main/java/com/camerapoints/models/CameraPoint.java
+++ b/src/main/java/com/camerapoints/models/CameraPoint.java
@@ -8,6 +8,7 @@ public class CameraPoint
 {
 	public enum Direction
 	{
+		NONE(0, "Unchanged"),
 		NORTH(1, "North"),
 		EAST(2, "East"),
 		SOUTH(3, "South"),


### PR DESCRIPTION
The changes applied to the plugin-hub in https://github.com/runelite/plugin-hub/pull/11594 broke the ability to have a camera point that did not change your compass point.

This change fixes this.

Tested in-game:

https://github.com/user-attachments/assets/b4cf0247-17d6-4442-b910-b75d25029f48