### PR TITLE
fix: recover old points

### DIFF
--- a/src/main/java/com/camerapoints/CameraPointGroupManager.java
+++ b/src/main/java/com/camerapoints/CameraPointGroupManager.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 public class CameraPointGroupManager
 {
 	private final List<CameraPointGroup> groups = new ArrayList<>();
-	private final Map<Integer, Integer> currentPointIds = new HashMap<>();
+	private final Map<Integer, Long> currentPointIds = new HashMap<>();
 
 	public void setGroups(List<CameraPointGroup> groups)
 	{
@@ -63,14 +63,14 @@ public class CameraPointGroupManager
 
 	public void addPointToGroup(CameraPointGroup group, CameraPoint point)
 	{
-		int nextId = group.getPoints().stream().map(CameraPoint::getId).max(Integer::compareTo).map(i -> i + 1).orElse(0);
+		long nextId = group.getPoints().stream().map(CameraPoint::getId).max(Long::compareTo).map(i -> i + 1).orElse(0L);
 		point.setId(nextId);
 		group.getPoints().add(point);
 	}
 
 	public CameraPoint addPointToGroup(CameraPointGroup group)
 	{
-		int nextId = group.getPoints().stream().map(CameraPoint::getId).max(Integer::compareTo).map(i -> i + 1).orElse(0);
+		long nextId = group.getPoints().stream().map(CameraPoint::getId).max(Long::compareTo).map(i -> i + 1).orElse(0L);
 		CameraPoint newPoint = new CameraPoint(nextId, "New Camera Point", CameraPoint.Direction.NORTH, -1, false, Keybind.NOT_SET, true);
 		addPointToGroup(group, newPoint);
 		return newPoint;
@@ -100,14 +100,14 @@ public class CameraPointGroupManager
 
 	public List<CameraPoint> getAllPointsForGroup(CameraPointGroup group)
 	{
-		return group.getPoints().stream().sorted(Comparator.comparingInt(CameraPoint::getId)).collect(Collectors.toList());
+		return group.getPoints().stream().sorted(Comparator.comparingLong(CameraPoint::getId)).collect(Collectors.toList());
 	}
 
 	public List<CameraPoint> getEnabledPointsForGroup(CameraPointGroup group)
 	{
 		return group.getPoints().stream()
 			.filter(CameraPoint::isEnabled)
-			.sorted(Comparator.comparingInt(CameraPoint::getId))
+			.sorted(Comparator.comparingLong(CameraPoint::getId))
 			.collect(Collectors.toList());
 	}
 
@@ -124,7 +124,7 @@ public class CameraPointGroupManager
 			return null;
 		}
 
-		Integer currentPointId = currentPointIds.get(group.getId());
+		Long currentPointId = currentPointIds.get(group.getId());
 		int currentIndex = -1;
 		for (int i = 0; i < enabledPoints.size(); i++)
 		{
@@ -148,7 +148,7 @@ public class CameraPointGroupManager
 			return null;
 		}
 
-		Integer currentPointId = currentPointIds.get(group.getId());
+		Long currentPointId = currentPointIds.get(group.getId());
 		int currentIndex = -1;
 		for (int i = 0; i < enabledPoints.size(); i++)
 		{

--- a/src/main/java/com/camerapoints/CameraPointsPlugin.java
+++ b/src/main/java/com/camerapoints/CameraPointsPlugin.java
@@ -11,6 +11,7 @@ import net.runelite.api.ScriptID;
 import net.runelite.api.gameval.VarClientID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.Keybind;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -165,15 +166,43 @@ public class CameraPointsPlugin extends Plugin
 
 	public void loadConfig()
 	{
-		String version = configManager.getConfiguration(CameraPointsConfig.CONFIG_GROUP, "version");
-		if (!CURRENT_VERISON.equals(version))
-		{
-			return;
-		}
 		String groupsJson = configManager.getConfiguration(CameraPointsConfig.CONFIG_GROUP, "groups");
-		CameraPointGroup[] groups = gson.fromJson(groupsJson, CameraPointGroup[].class);
-		List<CameraPointGroup> groupList = groups == null ? java.util.Collections.emptyList() : Arrays.asList(groups);
-		cameraPointGroupManager.setGroups(groupList);
+		if (groupsJson != null && !groupsJson.isEmpty())
+		{
+			// Load groups from "groups" json
+			CameraPointGroup[] groups = gson.fromJson(groupsJson, CameraPointGroup[].class);
+			List<CameraPointGroup> groupList = groups == null ? java.util.Collections.emptyList() : Arrays.asList(groups);
+			cameraPointGroupManager.setGroups(groupList);
+		}
+
+		// Check if user has old points from v2 version of plugin
+		String oldPointsJson = configManager.getConfiguration(CameraPointsConfig.CONFIG_GROUP, "points");
+		if (oldPointsJson != null && !oldPointsJson.isEmpty())
+		{
+			CameraPoint[] oldPoints = gson.fromJson(oldPointsJson, CameraPoint[].class);
+			if (oldPoints != null && oldPoints.length > 0)
+			{
+				// Found old points from the v2 version
+				for (var oldPoint : oldPoints)
+				{
+					// Enable them all since "enabled" is new with v3
+					oldPoint.setEnabled(true);
+				}
+
+				// Add all points into a new group called "Old"
+
+				var recoveredGroup = new CameraPointGroup(-1, "Old", true, Keybind.NOT_SET, Keybind.NOT_SET, Arrays.asList(oldPoints));
+				cameraPointGroupManager.addGroup(recoveredGroup);
+
+				// Save the points to "oldPoints" as an extra backup, and unset
+				// "points" so this recovery step doesn't continue to be called.
+				configManager.setConfiguration(CameraPointsConfig.CONFIG_GROUP, "oldPoints", oldPointsJson);
+				configManager.unsetConfiguration(CameraPointsConfig.CONFIG_GROUP, "points");
+
+				// Save the updated groups under "groups"
+				this.updateConfig();
+			}
+		}
 	}
 
 	public void updateConfig()

--- a/src/main/java/com/camerapoints/models/CameraPoint.java
+++ b/src/main/java/com/camerapoints/models/CameraPoint.java
@@ -52,7 +52,7 @@ public class CameraPoint
 		}
 	}
 
-	private int id;
+	private long id;
 	private String name;
 	private Direction direction;
 	private int zoom;
@@ -60,7 +60,7 @@ public class CameraPoint
 	private Keybind keybind;
 	private boolean enabled;
 
-	public CameraPoint(int id, String name, Direction direction, int zoom, boolean applyZoom, Keybind keybind, boolean enabled)
+	public CameraPoint(long id, String name, Direction direction, int zoom, boolean applyZoom, Keybind keybind, boolean enabled)
 	{
 		this.id = id;
 		this.name = name;
@@ -71,12 +71,12 @@ public class CameraPoint
 		this.enabled = enabled;
 	}
 
-	public int getId()
+	public long getId()
 	{
 		return id;
 	}
 
-	public void setId(int id)
+	public void setId(long id)
 	{
 		this.id = id;
 	}


### PR DESCRIPTION
With the change to v3, all old points from v2 were lost.

This PR adds the code required to load the old points into the new group system.
It loads old points into a new group called "Old" - happy to change the name if you don't like that.

<img width="244" height="317" alt="image" src="https://github.com/user-attachments/assets/cf747a5a-b879-4e25-be83-518872a90962" />

~~Pending #11 to ensure loading of old points work as expected.~~
